### PR TITLE
Adding OilTankVision to current projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Jeff has been working on the following projects on stream:
 
 * [Fritz.StreamTools](https://github.com/csharpfritz/Fritz.StreamTools) - (Formerly called RunDown) An ASP.NET Core project that will manage show information for streamers and provide easy browser-based plugins for your video content.
 * [CoreWiki](https://github.com/csharpfritz/CoreWiki) - An ASP.NET Core based content management system that has been built from scratch as a learner's project on stream.
+* [OilTankVision](https://github.com/csharpfritz/OilTankVision) - An IoT and Azure project that uses a Raspberry Pi to convert an analog oil-tank meter into a digital one.
 
 ## Former Projects
 


### PR DESCRIPTION
This adds the OilTankVision project into the Current Projects section of the README.